### PR TITLE
Re-Introduce BCrypt.DEFAULT_MAX_PW_LENGTH_BYTE to be code compatible …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Releases
 
+## v0.10.1
+
+* Re-Introduce DEFAULT_MAX_PW_LENGTH_BYTE to be code compatible with 0.9.0- (thx for the hint @Andrew-Cottrell)
+
 ## v0.10.0
 
 * [BREAKING CHANGE] the null terminator will not be counted to the 72 byte max length anymore. This changes the behaviour IF you used passwords with EXACTLY 72 bytes. #43, #44 (thx @quinot)

--- a/modules/bcrypt-cli/pom.xml
+++ b/modules/bcrypt-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>bcrypt-parent</artifactId>
         <groupId>at.favre.lib</groupId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
-            <version>0.10.0</version>
+            <version>0.10.1</version>
             <classifier>optimized</classifier>
         </dependency>
         <dependency>

--- a/modules/bcrypt/pom.xml
+++ b/modules/bcrypt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>bcrypt-parent</artifactId>
         <groupId>at.favre.lib</groupId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/modules/bcrypt/src/main/java/at/favre/lib/crypto/bcrypt/BCrypt.java
+++ b/modules/bcrypt/src/main/java/at/favre/lib/crypto/bcrypt/BCrypt.java
@@ -712,6 +712,13 @@ public final class BCrypt {
         public static final int MAX_PW_LENGTH_BYTE = 72;
 
         /**
+         * The max length of the password in bytes excluding lats null-terminator byte.
+         * @deprecated this will return 71 which is not correct, the null terminator should not count towards the full length if the pw is exactly 72. Use {@link #MAX_PW_LENGTH_BYTE} instead. See https://github.com/patrickfav/bcrypt/pull/44
+         */
+        @Deprecated
+        public static final int DEFAULT_MAX_PW_LENGTH_BYTE = MAX_PW_LENGTH_BYTE - 1;
+
+        /**
          * $2a$
          * <p>
          * The original specification did not define how to handle non-ASCII character, nor how to handle a null

--- a/modules/benchmark-jmh/pom.xml
+++ b/modules/benchmark-jmh/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>bcrypt-parent</artifactId>
         <groupId>at.favre.lib</groupId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
-            <version>0.10.0</version>
+            <version>0.10.1</version>
             <classifier>optimized</classifier>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>bcrypt-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
 
     <url>https://github.com/patrickfav/bcrypt</url>
     <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
…with older versions