### PR TITLE
Remove errorprone and proguard optimized version to be able to build …

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven
         run: ./mvnw -B clean package checkstyle:checkstyle jacoco:report -DcommonConfig.jarSign.skip=true
@@ -41,8 +41,8 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username in deploy

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--DcommonConfig.compiler.profile=jdk7_w_errorprone
+-DcommonConfig.compiler.profile=jdk7

--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ the plugin versions aswell as providing the checkstyle config rules. Specificall
 
 ## Tech Stack
 
-* Java 7 (+ [errorprone](https://github.com/google/error-prone) static analyzer)
-* Maven
+* Java 7 Source, JDK 11 required to build (not yet JDK17 compatible)
+* Maven 3
 
 ## Libraries & Credits
 

--- a/modules/bcrypt-cli/pom.xml
+++ b/modules/bcrypt-cli/pom.xml
@@ -58,7 +58,6 @@
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
             <version>0.10.2</version>
-            <classifier>optimized</classifier>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/modules/bcrypt/pom.xml
+++ b/modules/bcrypt/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <!--suppress UnresolvedMavenProperty -->
         <commonConfig.jarSign.keystore>${session.executionRootDirectory}/keystore.jks</commonConfig.jarSign.keystore>
     </properties>
 
@@ -30,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>5.1.8</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>
@@ -54,10 +55,6 @@
                 <artifactId>checksum-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.github.wvengen</groupId>
-                <artifactId>proguard-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>
             </plugin>
@@ -68,7 +65,6 @@
         <dependency>
             <groupId>at.favre.lib</groupId>
             <artifactId>bytes</artifactId>
-            <version>1.5.0</version>
         </dependency>
 
         <!-- test -->

--- a/modules/benchmark-jmh/pom.xml
+++ b/modules/benchmark-jmh/pom.xml
@@ -75,7 +75,6 @@
             <groupId>at.favre.lib</groupId>
             <artifactId>bcrypt</artifactId>
             <version>0.10.2</version>
-            <classifier>optimized</classifier>
         </dependency>
         <dependency>
             <groupId>org.mindrot</groupId>


### PR DESCRIPTION
…with JDK11

Not yet JDK17 compatible, CLI modile throws "InaccessibleObjectException" for PrintStream.