### PR TITLE
Update README.md to add Gradle quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The code is compiled with target [Java 7](https://en.wikipedia.org/wiki/Java_ver
 
 ## Quickstart
 
+This library is published to Maven Central
+
 Add the dependency of the [latest version](https://github.com/patrickfav/bcrypt/releases/latest) to your `pom.xml`:
 
 ```xml
@@ -21,6 +23,12 @@ Add the dependency of the [latest version](https://github.com/patrickfav/bcrypt/
     <artifactId>bcrypt</artifactId>
     <version>{latest-version}</version>
 </dependency>
+```
+
+Or if you are using Gradle:
+
+```groovy
+implementation("at.favre.lib:bcrypt:{latest-version}")
 ```
 
 A simple example:


### PR DESCRIPTION
Since the library can be used in Gradle projects, most of developers nowadays uses Gradle as a build system, this simple PR provide the option to copy and paste the dependency quickly for new developers, some new developers are not familiar with maven pom xml