### PR TITLE
Bump JDK version on Github Actions

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
       - name: Build with Maven
         run: ./mvnw -B clean verify -DcommonConfig.jarSign.skip=true


### PR DESCRIPTION
SonarQube analysis failed due to an unsupoorted Java version